### PR TITLE
Handles missing filesize in video/audio formats

### DIFF
--- a/ytdl_inline_bot/handlers.py
+++ b/ytdl_inline_bot/handlers.py
@@ -135,7 +135,9 @@ async def download_video_and_replace(url: str, inline_message_id: str, user_id: 
             raise Exception(f"No suitable audio format found under {MAX_AUDIO_SIZE} bytes.")
 
         # Check if total size exceeds MAX_TG_FILE_SIZE
-        total_size: int = metadata.best_video['filesize'] + metadata.best_audio['filesize']
+        video_size: int = metadata.best_video.get('filesize') or 0
+        audio_size: int = metadata.best_audio.get('filesize') or 0
+        total_size: int = video_size + audio_size
         if total_size > MAX_TG_FILE_SIZE:
             raise Exception(f"Combined video and audio filesize ({total_size} bytes) exceeds {MAX_TG_FILE_SIZE // (1024 * 1024)} MB limit.")
 

--- a/ytdl_inline_bot/utils.py
+++ b/ytdl_inline_bot/utils.py
@@ -135,13 +135,14 @@ def get_best_video_audio_format(url: str) -> VideoMetadata:
     
     # Find the best video format that meets our size constraints
     for f in sorted(video_formats, key=lambda x: x.get('height', 0), reverse=True):
-        if f.get('filesize', 0) <= MAX_VIDEO_SIZE:
+        filesize: int = f.get('filesize') or 0
+        if filesize > 0 and filesize <= MAX_VIDEO_SIZE:
             best_video = f
             break
     
     # If no video format meets our constraints, get the smallest one
     if not best_video and video_formats:
-        best_video = min(video_formats, key=lambda x: x.get('filesize', float('inf')))
+        best_video = min(video_formats, key=lambda x: x.get('filesize') or float('inf'))
     
     # Find the best audio format
     audio_formats = [f for f in formats if f.get('acodec') != 'none' and f.get('filesize')]
@@ -149,7 +150,8 @@ def get_best_video_audio_format(url: str) -> VideoMetadata:
     # Prioritize audio formats by language preference
     for lang in PREFERRED_AUDIO_LANGUAGES:
         for f in sorted(audio_formats, key=lambda x: x.get('abr', 0), reverse=True):
-            if f.get('filesize', 0) <= MAX_AUDIO_SIZE:
+            filesize: int = f.get('filesize') or 0
+            if filesize > 0 and filesize <= MAX_AUDIO_SIZE:
                 if f.get('language') == lang or lang.startswith(f.get('language', '')):
                     best_audio = f
                     break
@@ -159,13 +161,14 @@ def get_best_video_audio_format(url: str) -> VideoMetadata:
     # If no language preference match, get the best quality audio that meets size constraints
     if not best_audio:
         for f in sorted(audio_formats, key=lambda x: x.get('abr', 0), reverse=True):
-            if f.get('filesize', 0) <= MAX_AUDIO_SIZE:
+            filesize: int = f.get('filesize') or 0
+            if filesize > 0 and filesize <= MAX_AUDIO_SIZE:
                 best_audio = f
                 break
     
     # If no audio format meets our constraints, get the smallest one
     if not best_audio and audio_formats:
-        best_audio = min(audio_formats, key=lambda x: x.get('filesize', float('inf')))
+        best_audio = min(audio_formats, key=lambda x: x.get('filesize') or float('inf'))
     
     width = None
     height = None

--- a/ytdl_inline_bot/utils.py
+++ b/ytdl_inline_bot/utils.py
@@ -135,8 +135,8 @@ def get_best_video_audio_format(url: str) -> VideoMetadata:
     
     # Find the best video format that meets our size constraints
     for f in sorted(video_formats, key=lambda x: x.get('height', 0), reverse=True):
-        filesize: int = f.get('filesize') or 0
-        if filesize > 0 and filesize <= MAX_VIDEO_SIZE:
+        video_filesize: int = f.get('filesize') or 0
+        if video_filesize > 0 and video_filesize <= MAX_VIDEO_SIZE:
             best_video = f
             break
     
@@ -150,8 +150,8 @@ def get_best_video_audio_format(url: str) -> VideoMetadata:
     # Prioritize audio formats by language preference
     for lang in PREFERRED_AUDIO_LANGUAGES:
         for f in sorted(audio_formats, key=lambda x: x.get('abr', 0), reverse=True):
-            filesize: int = f.get('filesize') or 0
-            if filesize > 0 and filesize <= MAX_AUDIO_SIZE:
+            audio_filesize_lang: int = f.get('filesize') or 0
+            if audio_filesize_lang > 0 and audio_filesize_lang <= MAX_AUDIO_SIZE:
                 if f.get('language') == lang or lang.startswith(f.get('language', '')):
                     best_audio = f
                     break
@@ -161,8 +161,8 @@ def get_best_video_audio_format(url: str) -> VideoMetadata:
     # If no language preference match, get the best quality audio that meets size constraints
     if not best_audio:
         for f in sorted(audio_formats, key=lambda x: x.get('abr', 0), reverse=True):
-            filesize: int = f.get('filesize') or 0
-            if filesize > 0 and filesize <= MAX_AUDIO_SIZE:
+            audio_filesize: int = f.get('filesize') or 0
+            if audio_filesize > 0 and audio_filesize <= MAX_AUDIO_SIZE:
                 best_audio = f
                 break
     


### PR DESCRIPTION
Ensures the bot gracefully handles cases where filesize
information is missing in video or audio format metadata
from youtube-dl. This prevents potential errors when
calculating total file size or when sorting/filtering
formats based on size.
