### PR TITLE
Removes ARM64 build platform

### DIFF
--- a/.github/workflows/build_and_push.yml
+++ b/.github/workflows/build_and_push.yml
@@ -44,4 +44,3 @@ jobs:
             ${{ vars.DOCKER_REGISTRY }}/${{ vars.DOCKER_IMAGE }}:latest
           platforms: |
             linux/amd64
-            linux/arm64/v8


### PR DESCRIPTION
Removes the ARM64 platform from the build matrix.

This reduces build times and complexity as the platform is currently not a primary target.
